### PR TITLE
Retargets terminal-in-react Fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ node_js:
 
 dist: xenial
 os: linux
+
+install: npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "spiel-front",
-  "version": "1.0.4",
+  "name": "bogl-editor",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -10252,9 +10252,9 @@
       }
     },
     "platform": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
-      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q=="
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "pn": {
       "version": "1.1.0",
@@ -13730,12 +13730,12 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-          "integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
           "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
           }
         },
         "has-flag": {
@@ -13867,9 +13867,8 @@
       "integrity": "sha1-ofzMBrWNth/XpF2i2kT186Pme6I="
     },
     "terminal-in-react": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/terminal-in-react/-/terminal-in-react-4.3.1.tgz",
-      "integrity": "sha1-ouI2oemnf9aVG+xwInqpahuUd8Q=",
+      "version": "git+https://github.com/montymxb/terminal-in-react.git#5bb2bf61f0bdd61ef237b4948eaea77202dbb7f2",
+      "from": "git+https://github.com/montymxb/terminal-in-react.git",
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "lodash.isequal": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "spiel-front",
-  "version": "1.0.4",
+  "name": "bogl-editor",
+  "version": "1.1.0",
   "homepage": "./",
   "private": true,
   "dependencies": {
@@ -26,11 +26,11 @@
     "react-icons-kit": "^1.3.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.3.0",
-    "terminal-in-react": "^4.3.1",
+    "terminal-in-react": "git+https://github.com/montymxb/terminal-in-react.git",
     "webpack": "4.41.2"
   },
   "scripts": {
-    "setup": "npm install && cd .. && git clone https://github.com/The-Code-In-Sheep-s-Clothing/Spiel-Lang.git && cd Spiel-Lang && stack build && stack install",
+    "setup": "npm install && cd .. && git clone https://github.com/The-Code-In-Sheep-s-Clothing/bogl.git && cd bogl && stack build && stack install",
     "start": "PORT=5168 react-scripts start",
     "startProduction": "(react-scripts start &>/dev/null &) && spielserver 5174",
     "stopProduction": "react-scripts stop",


### PR DESCRIPTION
Closes #66 by allowing whitespace before a valid command. Retargets a fork of the terminal-in-react project that I created. The project has had a slight change to first trim whitespace off the the commands before they are split by whitespace. Checked this locally, and seems to effectively mitigate the problem. You have to run `npm install` to get the changes, but it does appear to get stuck on the initial change to the new project. If this happens, just remove the `node_modules/terminal-in-react` folder, and reinstall. I'll probably do the same by hand to guide the server when it takes this update.