### PR TITLE
Add Default Program for Exprs, and Download as Game Name

### DIFF
--- a/src/Navbar/SpielNavbar.tsx
+++ b/src/Navbar/SpielNavbar.tsx
@@ -10,6 +10,7 @@ import queryString from 'query-string';
 import { Icon } from 'react-icons-kit'
 import {shareAlt} from 'react-icons-kit/fa/shareAlt'
 import {undo} from 'react-icons-kit/fa/undo'
+import {extractGameNameFromProgram} from '../Utilities/ProgramUtils'
 
 import './SpielNavbar.css';
 
@@ -48,7 +49,7 @@ const SpielNavbar = (props) => {
 
       }
 
-      let fileName = props.downloadAsProgram ? "Program.bgl.txt" : "Prelude.bgl.txt";
+      let fileName = props.downloadAsProgram ? extractGameNameFromProgram(props.lastCode) + ".bgl.txt" : "Prelude.bgl.txt";
       let content = props.downloadAsProgram ? props.lastCode : props.lastPrelude;
 
       items.push(<Download key="downloadLink" content={content} link={fileName}/>);

--- a/src/Repl/Repl.tsx
+++ b/src/Repl/Repl.tsx
@@ -310,7 +310,7 @@ const Repl = (props) => {
 
       let pc = props.programCode;
       // only run this when we have program code (in testing this is not defined)
-      if(pc) {
+      if(pc !== undefined) {
         let pCheck = pc.replaceAll(/(?:--[^\n]*)/g,'').trim();
         if(pCheck === "") {
           // empty program, substitute a default program so we can run just expressions
@@ -319,7 +319,7 @@ const Repl = (props) => {
       }
 
       // extract game name, and in the case of an undefined program (when testing), supply a default definition to work with
-      let gameName = extractGameNameFromProgram(pc ? pc : "game DefaultTestingDefinition")
+      let gameName = extractGameNameFromProgram(pc !== undefined ? pc : "game DefaultTestingDefinition");
 
       apiRequestRunCode(requester, props.preludeCode, pc, replExpression, inputBuffer, gameName)
       .then(function(res) {

--- a/src/Repl/Repl.tsx
+++ b/src/Repl/Repl.tsx
@@ -9,7 +9,7 @@
 import React, { useState } from 'react';
 import Terminal from 'terminal-in-react';
 import {apiRequestRunCode} from '../Utilities/BoGLServerRequest';
-import {extractGameNameFromProgram} from '../Utilities/ProgramUtils';
+import {extractGameNameFromProgram,removeComments} from '../Utilities/ProgramUtils';
 import {decodeValue,decodeExprType,decodeError} from './Decode';
 
 
@@ -311,15 +311,15 @@ const Repl = (props) => {
       let pc = props.programCode;
       // only run this when we have program code (in testing this is not defined)
       if(pc !== undefined) {
-        let pCheck = pc.replaceAll(/(?:--[^\n]*)/g,'').trim();
+        let pCheck = removeComments(pc)
         if(pCheck === "") {
           // empty program, substitute a default program so we can run just expressions
           pc = "game Expressions";
         }
       }
 
-      // extract game name, and in the case of an undefined program (when testing), supply a default definition to work with
-      let gameName = extractGameNameFromProgram(pc !== undefined ? pc : "game DefaultTestingDefinition");
+      // extract game name, and in the case of an undefined program (when testing), supply a default name to work with
+      let gameName = pc !== undefined ? extractGameNameFromProgram(pc) : "DefaultTestingDefinition";
 
       apiRequestRunCode(requester, props.preludeCode, pc, replExpression, inputBuffer, gameName)
       .then(function(res) {

--- a/src/Repl/Repl.tsx
+++ b/src/Repl/Repl.tsx
@@ -309,14 +309,17 @@ const Repl = (props) => {
       }
 
       let pc = props.programCode;
-      let pCheck = pc.replaceAll(/(?:--[^\n]*)/g,'').trim();
-      if(pCheck == "") {
-        // empty program, substitute a default program so we can run just expressions
-        pc = "game Expressions";
+      // only run this when we have program code (in testing this is not defined)
+      if(pc) {
+        let pCheck = pc.replaceAll(/(?:--[^\n]*)/g,'').trim();
+        if(pCheck === "") {
+          // empty program, substitute a default program so we can run just expressions
+          pc = "game Expressions";
+        }
       }
 
-      // extract game name
-      let gameName = extractGameNameFromProgram(pc)
+      // extract game name, and in the case of an undefined program (when testing), supply a default definition to work with
+      let gameName = extractGameNameFromProgram(pc ? pc : "game DefaultTestingDefinition")
 
       apiRequestRunCode(requester, props.preludeCode, pc, replExpression, inputBuffer, gameName)
       .then(function(res) {

--- a/src/Repl/Repl.tsx
+++ b/src/Repl/Repl.tsx
@@ -9,6 +9,7 @@
 import React, { useState } from 'react';
 import Terminal from 'terminal-in-react';
 import {apiRequestRunCode} from '../Utilities/BoGLServerRequest';
+import {extractGameNameFromProgram} from '../Utilities/ProgramUtils';
 import {decodeValue,decodeExprType,decodeError} from './Decode';
 
 
@@ -307,7 +308,17 @@ const Repl = (props) => {
 
       }
 
-      apiRequestRunCode(requester, props.preludeCode, props.programCode, replExpression, inputBuffer)
+      let pc = props.programCode;
+      let pCheck = pc.replaceAll(/(?:--[^\n]*)/g,'').trim();
+      if(pCheck == "") {
+        // empty program, substitute a default program so we can run just expressions
+        pc = "game Expressions";
+      }
+
+      // extract game name
+      let gameName = extractGameNameFromProgram(pc)
+
+      apiRequestRunCode(requester, props.preludeCode, pc, replExpression, inputBuffer, gameName)
       .then(function(res) {
         // store & decode the response
         respStatus = res.status;

--- a/src/Utilities/BoGLServerRequest.tsx
+++ b/src/Utilities/BoGLServerRequest.tsx
@@ -74,7 +74,7 @@ const apiRequestLoad = (request, id) => {
  * expr:        Expression to evaluate in the context of the code & prelude (string)
  * inputBuffer: Array of strings to send as input ([string])
  */
-const apiRequestRunCode = (request, prelude, prog, expr, inputBuffer) => {
+const apiRequestRunCode = (request, prelude, prog, expr, inputBuffer, programName) => {
   return request(BOGL_API+'/runCode', {
       method: 'POST',
       headers: postHeaders,
@@ -83,7 +83,7 @@ const apiRequestRunCode = (request, prelude, prog, expr, inputBuffer) => {
           file: prog,       // program contents
           input: expr,      // expr to evaluate in the context of prelude & prog
           buffer: inputBuffer,  // input buffer to utilize for 'input' refs
-          programName: "Program"
+          programName: programName  // program name to use
       }),
   })
 }

--- a/src/Utilities/ProgramUtils.tsx
+++ b/src/Utilities/ProgramUtils.tsx
@@ -1,0 +1,29 @@
+/*
+ * ProgramUtils.tsx
+ * Created Feb. 20th, 2021
+ * Ben Friedman
+ *
+ * Holds utilities for working on bogl programs
+ */
+
+/*
+ * extractGameNameFromProgram
+ *
+ * Takes a string of a concrete bogl program, and extracts the game name (if present),
+ * otherwise defaults to 'Program'
+ */
+const extractGameNameFromProgram = pc => {
+  // extract game name, opting for a longer name first, and then a shorter name after
+  // if a longer name is not able to be matched
+  let gnMatch = pc.match(/game\s+([A-Z][A-Za-z0-9_]+)|([A-Z])/);
+
+  if(gnMatch && gnMatch.length >= 2) {
+    return gnMatch[1];
+  } else {
+    return "Program";
+  }
+};
+
+export {
+  extractGameNameFromProgram
+}

--- a/src/Utilities/ProgramUtils.tsx
+++ b/src/Utilities/ProgramUtils.tsx
@@ -15,7 +15,7 @@
 const extractGameNameFromProgram = pc => {
   // extract game name, opting for a longer name first, and then a shorter name after
   // if a longer name is not able to be matched
-  let gnMatch = pc.match(/game\s+([A-Z][A-Za-z0-9_]+)|([A-Z])/);
+  let gnMatch = removeComments(pc).match(/game\s+([A-Z][A-Za-z0-9_]+|[A-Z])/);
 
   if(gnMatch && gnMatch.length >= 2) {
     return gnMatch[1];
@@ -24,6 +24,14 @@ const extractGameNameFromProgram = pc => {
   }
 };
 
+/*
+ * removeComments
+ *
+ * Takes a program string, removes all block comments, then single line comments, then trims leading & trailing whitespace
+ */
+const removeComments = pc => pc.replaceAll(/{-(?:.|\n)*-}/g,'').replaceAll(/--[^\n]*/g,'').trim();
+
 export {
+  removeComments,
   extractGameNameFromProgram
 }


### PR DESCRIPTION
Default program is `game Expressions` when no program is found in the editor, but an expression is passed. Single line comments don't factor into whether a program is present, so this works as well:
```haskell
-- this will be a program
-- just for running
-- exprs in the repl
```
However I didn't set it up for multi-line comments, but this should suffice in the meantime.

Although the game name does not come back in the response, I was able to use some simple regex to find and extract it directly from the concrete syntax, before sending it over to the server. This wasn't too hard after all, and in the case that it does fail, it defaults back to 'Program' as it was before.